### PR TITLE
new features for tf.sh

### DIFF
--- a/tf.sh
+++ b/tf.sh
@@ -115,10 +115,12 @@ ${TF_TERRAFORM_EXECUTABLE} init -backend-config "key=${TF_STATE_PATH}" -backend-
 
 # figure out which env file to use
 if [ -e ./${TF_ENVIRONMENT_ID}.tfvars ]; then
-  export TF_CLI_ARGS_plan="-var-file=./${TF_ENVIRONMENT_ID}.tfvars"
-  export TF_CLI_ARGS_import="-var-file=./${TF_ENVIRONMENT_ID}.tfvars"
   # If we are not applying saving plan, add -var-file
-  [ -z "${TF_AUTO_APPLY_SAVED_PLAN}" ] && export TF_CLI_ARGS_apply="-var-file=./${TF_ENVIRONMENT_ID}.tfvars -auto-approve"
+  if [ -z "${TF_AUTO_APPLY_SAVED_PLAN}" ]; then
+    export TF_CLI_ARGS="-var-file=./${TF_ENVIRONMENT_ID}.tfvars"
+    # Add -auto-approve for any apply commands
+    export TF_CLI_ARGS_apply="-var-file=./${TF_ENVIRONMENT_ID}.tfvars -auto-approve"
+  fi
 fi
 
 ${TF_TERRAFORM_EXECUTABLE} $*

--- a/tf.sh
+++ b/tf.sh
@@ -28,9 +28,6 @@ if [ -z "${HASHE_COMMAND}" ] ; then HASHE_COMMAND=${HASHE_COMMAND:-sha1sum} ; fi
 # Set terraform version
 [ -e ./.terraform_executable ] && export TF_TERRAFORM_EXECUTABLE="$(cat .terraform_executable)"
 
-# Clean .terraform/terraform.tfstate 
-[ -n "${TF_CLEAN_DOT_STATE_FILE}" ] && rm -rf .terraform/terraform.tfstate
-
 # Enable TF_DATA_DIR_PER_ENV
 [ -n "${TF_DATA_DIR_PER_ENV}" ] && export TF_DATA_DIR=".terraform.${TF_ENVIRONMENT_ID}"
 

--- a/tf.sh
+++ b/tf.sh
@@ -23,7 +23,7 @@ fi
 
 if [ -z "${TF_CLEAN_DOT_STATE_FILE}" ] ; then TF_CLEAN_DOT_STATE_FILE={$TF_CLEAN_DOT_STATE_FILE:-} ; fi
 if [ -z "${TF_DATA_DIR_PER_ENV}" ] ; then TF_DATA_DIR_PER_ENV=${TF_DATA_DIR_PER_ENV:-} ; fi
-if [ -z "${HASHE_COMMAND}" ] ; then HASHE_COMMAND=${HASHE_COMMAND:-sha1sum} ; fi
+if [ -z "${HASH_COMMAND}" ] ; then HASH_COMMAND=${HASH_COMMAND:-sha1sum} ; fi
 
 # Set terraform version
 [ -e ./.terraform_executable ] && export TF_TERRAFORM_EXECUTABLE="$(cat .terraform_executable)"
@@ -83,12 +83,12 @@ if [ -z "${TF_STATE_BUCKET}" ]; then
     # Use hashed environment id to avoid account id/region disclosure via S3 DNS name
     # in this way it is hard to predict the bucket name and attacker won't be able to
     # setup buckets in advance to capture your state file
-    HASHED_ENVIRONMENT_ID=$(echo -n ${TF_ENVIRONMENT_ID} | "${HASHE_COMMAND}" | awk '{print $1}')
+    HASHED_ENVIRONMENT_ID=$(echo -n ${TF_ENVIRONMENT_ID} | "${HASH_COMMAND}" | awk '{print $1}')
     export TF_STATE_BUCKET="terraform-state-${HASHED_ENVIRONMENT_ID}"
 fi
 
 if [ -z "${TF_STATE_DYNAMODB_TABLE}" ]; then
-    HASHED_ENVIRONMENT_ID=$(echo -n ${TF_ENVIRONMENT_ID} | "${HASHE_COMMAND}" | awk '{print $1}')
+    HASHED_ENVIRONMENT_ID=$(echo -n ${TF_ENVIRONMENT_ID} | "${HASH_COMMAND}" | awk '{print $1}')
     export TF_STATE_DYNAMODB_TABLE="terraform-state-${HASHED_ENVIRONMENT_ID}"
 fi
 

--- a/tf.sh
+++ b/tf.sh
@@ -21,7 +21,6 @@ if [ -f tf.sh.env ]; then
     export $(cat tf.sh.env | grep -v '#' | awk '/=/ {print $1}')
 fi
 
-if [ -z "${TF_CLEAN_DOT_STATE_FILE}" ] ; then TF_CLEAN_DOT_STATE_FILE={$TF_CLEAN_DOT_STATE_FILE:-} ; fi
 if [ -z "${TF_DATA_DIR_PER_ENV}" ] ; then TF_DATA_DIR_PER_ENV=${TF_DATA_DIR_PER_ENV:-} ; fi
 if [ -z "${HASH_COMMAND}" ] ; then HASH_COMMAND=${HASH_COMMAND:-sha1sum} ; fi
 

--- a/tf.sh
+++ b/tf.sh
@@ -116,6 +116,7 @@ ${TF_TERRAFORM_EXECUTABLE} init -backend-config "key=${TF_STATE_PATH}" -backend-
 # figure out which env file to use
 if [ -e ./${TF_ENVIRONMENT_ID}.tfvars ]; then
   export TF_CLI_ARGS_plan="-var-file=./${TF_ENVIRONMENT_ID}.tfvars"
+  export TF_CLI_ARGS_import="-var-file=./${TF_ENVIRONMENT_ID}.tfvars"
   # If we are not applying saving plan, add -var-file
   [ -z "${TF_AUTO_APPLY_SAVED_PLAN}" ] && export TF_CLI_ARGS_apply="-var-file=./${TF_ENVIRONMENT_ID}.tfvars -auto-approve"
 fi

--- a/tf.sh
+++ b/tf.sh
@@ -118,7 +118,7 @@ if [ -e ./${TF_ENVIRONMENT_ID}.tfvars ]; then
   # If we are not applying saving plan, add -var-file
   if [ -z "${TF_AUTO_APPLY_SAVED_PLAN}" ]; then
     export TF_CLI_ARGS="-var-file=./${TF_ENVIRONMENT_ID}.tfvars"
-    # Add -auto-approve for any apply commands
+    # If we are applying changes, do not ask for interactive approval. Work for any apply commands (-destroy, -refresh-only and etc)
     export TF_CLI_ARGS_apply="-var-file=./${TF_ENVIRONMENT_ID}.tfvars -auto-approve"
   fi
 fi


### PR DESCRIPTION
add TF_STATE_DYNAMODB_TABLE for support state lock,
add TF_AUTO_APPLY_SAVED_PLAN for support apply saved plan,
add TF_VAR_terraform_state_location for pass state location to terraform (used for tags)
add -backend-config "encrypt=true", 
add TF_SKIP_BACKEND_INIT for support skip backend init and increase the speed of running
add TF_DATA_DIR_PER_ENV for use TF_DATA_DIR function and store data for different env
add HASH_COMMAND for support different hash commands with sha1sum by default
replace VAR_FILE, OPTIONS with TF_CLI_ARGS_plan and TF_CLI_ARGS_apply

add tf.sh.env file support for overwriting defaults without change tf.sh file
